### PR TITLE
Make the name of the Validation producing a ValidationResult an attribute of ValidationResult

### DIFF
--- a/sagemaker_rightline/rules.py
+++ b/sagemaker_rightline/rules.py
@@ -20,6 +20,7 @@ class Equals(Rule):
         self,
         observed: List[Union[int, float, str, dict]],
         expected: List[Union[int, float, str, dict]],
+        validation_name: str,
     ) -> ValidationResult:
         """Check if two lists are equal.
 
@@ -27,6 +28,8 @@ class Equals(Rule):
         :type observed: List[Any]
         :param expected: expected list
         :type expected: List[Any]
+        :param validation_name: name of the validation
+        :type validation_name: str
         :return: validation result
         :rtype: ValidationResult
         """
@@ -39,6 +42,7 @@ class Equals(Rule):
 
         is_equal = is_equal if not self.negative else not is_equal
         return ValidationResult(
+            validation_name=validation_name,
             success=is_equal,
             negative=self.negative,
             message=f"{str(observed)} does {'not ' if not is_equal else ''}equal {str(expected)}",
@@ -59,18 +63,24 @@ class Contains(Rule):
         """
         super().__init__("Contains", negative)
 
-    def run(self, observed: List[Any], expected: List[Any]) -> ValidationResult:
+    def run(
+        self, observed: List[Any], expected: List[Any], validation_name: str
+    ) -> ValidationResult:
         """Check if a list contains another list.
 
         :param observed: observed list
         :type observed: List[Any]
         :param expected: expected list
+        :type expected: List[Any]
+        :param validation_name: name of the validation
+        :type validation_name: str
         :return: validation result
         :rtype: ValidationResult
         """
         is_contained = set(expected).issubset(set(observed))
         is_contained = is_contained if not self.negative else not is_contained
         return ValidationResult(
+            validation_name=validation_name,
             success=is_contained,
             negative=self.negative,
             message=f"{str(observed)} does {'not ' if not is_contained else ''}contain "

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -42,18 +42,27 @@ def test_configuration_validate_input_validations(validations, error: bool) -> N
     [
         [
             ValidationResult(
-                success=True, negative=False, message="test-message", subject="test-subject-1"
+                success=True,
+                negative=False,
+                message="test-message",
+                subject="test-subject-1",
+                validation_name="test",
             )
         ],
         [
             ValidationResult(
-                success=True, negative=False, message="test-message-true", subject="test-subject-2"
+                success=True,
+                negative=False,
+                message="test-message-true",
+                subject="test-subject-2",
+                validation_name="test",
             ),
             ValidationResult(
                 success=False,
                 negative=False,
                 message="test-message-false",
                 subject="test-subject-3",
+                validation_name="test",
             ),
         ],
     ],
@@ -64,13 +73,6 @@ def test_configuration_make_report(results) -> None:
     assert isinstance(report, Report)
     assert isinstance(report.results, list)
     assert isinstance(report.results[0], ValidationResult)
-
-
-def flatten_report(report: Report) -> list:
-    flat_list = []
-    for result in report.results:
-        flat_list += result
-    return flat_list
 
 
 @mock_ecr
@@ -91,8 +93,7 @@ def test_configuration_run(sagemaker_pipeline, ecr_client, report_length, valida
         cf = Configuration(validations=validations, sagemaker_pipeline=sagemaker_pipeline)
         report = cf.run(fail_fast=False)
 
-    report_flat = flatten_report(report=report)
-    assert len(report_flat) == report_length
+    assert len(report.results) == report_length
 
 
 @mock_ecr
@@ -107,8 +108,7 @@ def test_configuration_run_fail_fast(sagemaker_pipeline, report_length, validati
     """Test run method of Configuration class."""
     cf = Configuration(validations=validations, sagemaker_pipeline=sagemaker_pipeline)
     report = cf.run(fail_fast=True)
-    report_flat = flatten_report(report=report)
-    assert len(report_flat) == report_length
+    assert len(report.results) == report_length
 
 
 def test_report_to_df() -> None:
@@ -116,16 +116,18 @@ def test_report_to_df() -> None:
     validation_name = "StepImagesExistOnEcr"
     report = Report(
         results=[
-            {
-                validation_name: ValidationResult(
-                    success=True, negative=False, message="test-message-0", subject="test-subject-0"
-                ),
-            }
+            ValidationResult(
+                success=True,
+                negative=False,
+                message="test-message-0",
+                subject="test-subject-0",
+                validation_name=validation_name,
+            ),
         ]
     )
     df = report.to_df()
     assert df.shape == (1, 5)
-    assert df.columns.tolist() == ["validation_name", "negative", "subject", "success", "message"]
+    assert df.columns.tolist() == list(ValidationResult.__annotations__.keys())
     assert df["success"].tolist() == [True]
     assert df["negative"].tolist() == [False]
     assert df["message"].tolist() == ["test-message-0"]

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -33,6 +33,7 @@ def test_equals(observed: List, expected: List, negative: bool, success: bool) -
     vr = equals.run(
         observed=observed,
         expected=expected,
+        validation_name="some-validation",
     )
     assert vr.success == success
 
@@ -62,5 +63,6 @@ def test_contains_str(
     vr = contains.run(
         observed=observed,
         expected=expected,
+        validation_name="some-validation",
     )
     assert vr.success == success

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -47,16 +47,19 @@ def test_validation_result() -> None:
     negative = True
     message = "test-message"
     subject = "test-subject"
+    validation_name = "test"
     vr = ValidationResult(
         success=success,
         negative=negative,
         message=message,
         subject=subject,
+        validation_name=validation_name,
     )
     assert vr.success == success
     assert vr.negative == negative
     assert vr.message == message
     assert vr.subject == subject
+    assert vr.validation_name == validation_name
 
 
 @mock_ecr
@@ -67,20 +70,20 @@ def test_image_exists_run_positive(ecr_client, sagemaker_pipeline) -> None:
     ]
     with create_image(ecr_client, container_images):
         image_exists = StepImagesExistOnEcr()
-        results = image_exists.run(sagemaker_pipeline)
+        result = image_exists.run(sagemaker_pipeline)
 
-    assert results[image_exists.name].success
-    assert not results[image_exists.name].negative
-    assert results[image_exists.name].message.endswith(" exist.")
+    assert result.success
+    assert not result.negative
+    assert result.message.endswith(" exist.")
 
 
 @mock_ecr
 def test_image_exists_run_negative(sagemaker_pipeline) -> None:
     image_exists = StepImagesExistOnEcr()
-    results = image_exists.run(sagemaker_pipeline)
+    result = image_exists.run(sagemaker_pipeline)
 
-    assert not results[image_exists.name].success
-    assert results[image_exists.name].message.endswith(" not exist.")
+    assert not result.success
+    assert result.message.endswith(" not exist.")
 
 
 @pytest.mark.parametrize(
@@ -115,8 +118,8 @@ def test_pipeline_parameters_equals(parameters_expected, success, sagemaker_pipe
         parameters_expected=parameters_expected,
         rule=Equals(),
     )
-    results = pipeline_parameters.run(sagemaker_pipeline)
-    assert results[pipeline_parameters.name].success == success
+    result = pipeline_parameters.run(sagemaker_pipeline)
+    assert result.success == success
 
 
 @pytest.mark.parametrize(
@@ -148,8 +151,8 @@ def test_pipeline_parameters_ignore_default_value(
         ignore_default_value=ignore_default_value,
         rule=Equals(),
     )
-    results = pipeline_parameters.run(sagemaker_pipeline)
-    assert results[pipeline_parameters.name].success == success
+    result = pipeline_parameters.run(sagemaker_pipeline)
+    assert result.success == success
 
 
 def test_has_parameters_raise() -> None:
@@ -169,10 +172,8 @@ def test_step_kms_key_id(kms_key_id_expected, success, sagemaker_pipeline) -> No
         kms_key_id_expected=kms_key_id_expected,
         rule=Equals(),
     )
-    results = has_kms_key_id_in_processing_output.run(sagemaker_pipeline)[
-        has_kms_key_id_in_processing_output.name
-    ]
-    assert results.success == success
+    result = has_kms_key_id_in_processing_output.run(sagemaker_pipeline)
+    assert result.success == success
 
 
 @pytest.mark.parametrize(
@@ -188,10 +189,8 @@ def test_step_kms_key_id_filter(kms_key_id_expected, success, sagemaker_pipeline
         step_name="sm_processing_step_sklearn",
         rule=Equals(),
     )
-    results = has_kms_key_id_in_processing_output.run(sagemaker_pipeline)[
-        has_kms_key_id_in_processing_output.name
-    ]
-    assert results.success == success
+    result = has_kms_key_id_in_processing_output.run(sagemaker_pipeline)
+    assert result.success == success
 
 
 @pytest.mark.parametrize(
@@ -206,10 +205,8 @@ def test_step_kms_key_id_no_filter(kms_key_id_expected, success, sagemaker_pipel
         kms_key_id_expected=kms_key_id_expected,
         rule=Equals(),
     )
-    results = has_kms_key_id_in_processing_output.run(sagemaker_pipeline)[
-        has_kms_key_id_in_processing_output.name
-    ]
-    assert results.success == success
+    result = has_kms_key_id_in_processing_output.run(sagemaker_pipeline)
+    assert result.success == success
 
 
 def test_get_filtered_attributes_steps(sagemaker_pipeline) -> None:
@@ -234,7 +231,7 @@ def test_step_network_config(
         network_config_expected=network_config_expected,
         rule=Equals(),
     )
-    results = step_network_config.run(sagemaker_pipeline)[step_network_config.name]
+    results = step_network_config.run(sagemaker_pipeline)
     assert not results.success
 
 
@@ -284,8 +281,8 @@ def test_step_network_config_filter(
         rule=Equals(),
         step_name=step_name,
     )
-    results = step_network_config.run(sagemaker_pipeline)[step_network_config.name]
-    assert results.success == success
+    result = step_network_config.run(sagemaker_pipeline)
+    assert result.success == success
 
 
 @mock_iam
@@ -293,12 +290,12 @@ def test_step_network_config_filter(
 def test_lambda_function_exists_positive(lambda_client, sagemaker_pipeline) -> None:
     with create_lambda_function(lambda_client, [TEST_LAMBDA_FUNC_NAME]):
         lambda_function_exists = StepLambdaFunctionExists()
-        results = lambda_function_exists.run(sagemaker_pipeline)
-    assert results[lambda_function_exists.name].success
+        result = lambda_function_exists.run(sagemaker_pipeline)
+    assert result.success
 
 
 @mock_lambda
 def test_lambda_function_exists_negative(lambda_client, sagemaker_pipeline) -> None:
     lambda_function_exists = StepLambdaFunctionExists()
-    results = lambda_function_exists.run(sagemaker_pipeline)
-    assert not results[lambda_function_exists.name].success
+    result = lambda_function_exists.run(sagemaker_pipeline)
+    assert not result.success


### PR DESCRIPTION
Fixes #22

# Proposed Changes
As elaborated on in the linked issue:
- A ValidationResult object stores the name of the Validation that it was generated by.
- The Validation.run methods are updated accordingly.
- Report.to_df is refactored to handle the different data structure appropriately.


# Maintenance
* [x] Updated tests
* [x] Updated documentation